### PR TITLE
feat: 통신 클라이언트를 구현하고 회원가입 로직을 통신 환경에 맞춰 변경한다

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,7 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="Embedded JDK" />
+        <option name="gradleJvm" value="corretto-11" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
@@ -26,7 +25,7 @@
       </map>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="corretto-11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,4 +39,9 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    implementation 'com.squareup.retrofit2:retrofit:2.6.4'
+    implementation 'com.squareup.retrofit2:converter-gson:2.6.4'
+    implementation 'com.squareup.retrofit2:converter-scalars:2.6.4'
+    implementation 'com.squareup.okhttp3:logging-interceptor:4.8.1'
+
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools" >
 
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
+        android:usesCleartextTraffic="true"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
@@ -39,5 +41,4 @@
             android:name=".SplashActivity"
             android:exported="false" />
     </application>
-
 </manifest>

--- a/app/src/main/java/com/example/bravohealthpark/AuthorityDto.java
+++ b/app/src/main/java/com/example/bravohealthpark/AuthorityDto.java
@@ -1,0 +1,16 @@
+package com.example.bravohealthpark;
+
+public class AuthorityDto {
+    private String authorityName;
+
+    public AuthorityDto(String authorityName) {
+        this.authorityName = authorityName;
+    }
+
+    @Override
+    public String toString() {
+        return "AuthorityDto{" +
+                "authorityName='" + authorityName + '\'' +
+                '}';
+    }
+}

--- a/app/src/main/java/com/example/bravohealthpark/RetrofitService.java
+++ b/app/src/main/java/com/example/bravohealthpark/RetrofitService.java
@@ -1,0 +1,13 @@
+package com.example.bravohealthpark;
+
+import com.example.bravohealthpark.SignupResult;
+import com.example.bravohealthpark.UserDto;
+
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.POST;
+
+public interface RetrofitService {
+    @POST("/user/signup")
+    Call<SignupResult> sendSignupRequest(@Body UserDto userDto);
+}

--- a/app/src/main/java/com/example/bravohealthpark/SignUpActivity.java
+++ b/app/src/main/java/com/example/bravohealthpark/SignUpActivity.java
@@ -1,16 +1,34 @@
 package com.example.bravohealthpark;
 
+import static com.example.bravohealthpark.retrofit.RetrofitClient.getApiService;
+
 import androidx.appcompat.app.AppCompatActivity;
 
-import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
+import android.widget.EditText;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.logging.HttpLoggingInterceptor;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.HttpException;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
 
 public class SignUpActivity extends AppCompatActivity {
 
     private Button signUpBtn;
+    private EditText editTextName, editTextPNumber, editTextId;
+    private RetrofitService retrofitService;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -18,14 +36,50 @@ public class SignUpActivity extends AppCompatActivity {
         setContentView(R.layout.activity_sign_up);
 
         signUpBtn = (Button) findViewById(R.id.SignUp_Btn);
+        editTextId = (EditText) findViewById(R.id.EditText_Id);
+        editTextName = (EditText) findViewById(R.id.EditText_Name);
+        editTextPNumber = (EditText) findViewById(R.id.EditText_PhoneNumber);
 
         signUpBtn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Intent intent = new Intent(getApplicationContext(), LoginActivity.class);
-                startActivity(intent);
+
+                retrofitService = getApiService();
+
+                HashSet<AuthorityDto> authorityDtoSet = new HashSet<>();
+                authorityDtoSet.add(new AuthorityDto("ROLE_USER"));
+                UserDto requestData = new UserDto(authorityDtoSet,
+                        editTextId.getText().toString(),
+                        editTextPNumber.getText().toString(),
+                        editTextName.getText().toString());
+                Call<SignupResult> call = retrofitService.sendSignupRequest(requestData);
+                call.enqueue(new Callback<SignupResult>() {
+                    @Override
+                    public void onResponse(Call<SignupResult> call, Response<SignupResult> response) {
+                        Intent intent = new Intent(getApplicationContext(), LoginActivity.class);
+                        startActivity(intent);
+                    }
+
+                    @Override
+                    public void onFailure(Call<SignupResult> call, Throwable t) {
+                        if (t instanceof IOException) {
+                            // 네트워크 연결 문제로 통신 실패한 경우
+                            // 예: 인터넷 연결 없음, 서버에 연결할 수 없음 등
+                            System.out.println("Network connection failed: " + t.getMessage());
+                        } else if (t instanceof HttpException) {
+                            // 서버로부터 응답을 받지 못한 경우 (HTTP 응답 코드가 2xx가 아닌 경우)
+                            // 예: 404 Not Found, 500 Internal Server Error 등
+                            HttpException httpException = (HttpException) t;
+                            int statusCode = httpException.code();
+                            String errorMessage = httpException.message();
+                            System.out.println("Server error - Status code: " + statusCode + ", Error message: " + errorMessage);
+                        } else {
+                            // 기타 예외 상황인 경우
+                            System.out.println("Error occurred: " + t.getMessage());
+                        }
+                    }
+                });
             }
         });
-
     }
 }

--- a/app/src/main/java/com/example/bravohealthpark/SignupResult.java
+++ b/app/src/main/java/com/example/bravohealthpark/SignupResult.java
@@ -1,0 +1,22 @@
+package com.example.bravohealthpark;
+
+import java.util.Set;
+
+
+public class SignupResult {
+
+    private Set<AuthorityDto> authorityDtoSet;
+    private String loginId;
+    private String phoneNumber;
+    private String username;
+
+    @Override
+    public String toString() {
+        return "SignupResult{" +
+                "authorityDtoSet=" + authorityDtoSet +
+                ", loginId='" + loginId + '\'' +
+                ", phoneNumber='" + phoneNumber + '\'' +
+                ", username='" + username + '\'' +
+                '}';
+    }
+}

--- a/app/src/main/java/com/example/bravohealthpark/UserDto.java
+++ b/app/src/main/java/com/example/bravohealthpark/UserDto.java
@@ -1,0 +1,30 @@
+package com.example.bravohealthpark;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class UserDto {
+    private Set<AuthorityDto> authorityDtoSet;
+    private String loginId;
+    private String phoneNumber;
+    private String username;
+
+    public UserDto(HashSet<AuthorityDto> authorityDtoSet, String loginId, String phoneNumber, String username) {
+        this.authorityDtoSet = authorityDtoSet;
+        this.loginId = loginId;
+        this.phoneNumber = phoneNumber;
+        this.username = username;
+    }
+
+    public void setLoginId(String loginId) {
+        this.loginId = loginId;
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+}

--- a/app/src/main/java/com/example/bravohealthpark/retrofit/RetrofitClient.java
+++ b/app/src/main/java/com/example/bravohealthpark/retrofit/RetrofitClient.java
@@ -1,0 +1,45 @@
+package com.example.bravohealthpark.retrofit;
+
+import android.widget.EditText;
+
+import com.example.bravohealthpark.R;
+import com.example.bravohealthpark.RetrofitService;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.util.Collections;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.logging.HttpLoggingInterceptor;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+public class RetrofitClient {
+    private static final String BASE_URL = "http://10.0.2.2:4903";
+    private static OkHttpClient.Builder httpClientBuilder;
+    private static HttpLoggingInterceptor loggingInterceptor;
+
+    public static RetrofitService getApiService() {
+        return getInstance().create(RetrofitService.class);
+    }
+
+    private static Retrofit getInstance(){
+        // OkHttpClient 빌더 생성
+        httpClientBuilder = new OkHttpClient.Builder();
+
+        // 로깅 인터셉터 추가
+        HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor();
+        loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
+        httpClientBuilder.addInterceptor(loggingInterceptor);
+
+        // TLS 버전 지정
+        httpClientBuilder.protocols(Collections.singletonList(Protocol.HTTP_1_1));
+
+        return new Retrofit.Builder()
+                .baseUrl(BASE_URL)
+                .addConverterFactory(GsonConverterFactory.create())
+                .client(httpClientBuilder.build()) // OkHttpClient 설정 적용
+                .build();
+    }
+}

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -38,17 +38,17 @@
     <TextView
         android:layout_width="match_parent"
         android:layout_height="60dp"
-        android:text="생년월일"
+        android:text="아이디"
         android:gravity="center_vertical"
         android:layout_marginLeft="5dp"
         android:textStyle="bold"
         android:textSize="25sp" />
     <EditText
         android:background="@drawable/shape_edittext"
-        android:id="@+id/EditText_Birth"
+        android:id="@+id/EditText_Id"
         android:layout_width="match_parent"
         android:layout_height="60dp"
-        android:hint="19491225"
+        android:hint="아이디를 적어주세요"
         android:textSize="20sp"
         android:inputType="textNoSuggestions" />
     <TextView


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `feat: PR을 등록한다.`
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 정상적으로 프로그램이 동작하나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 개요
서버와 통신하기 위해서 Retrofit를 이용한 Service Interface, Client를 구현합니다

## 작업 내용
* Retrofit Dependency 및 Internet Permission 추가
* Retrofit Client, Retrofit Service interface 생성
* Signup Activity, xml 변경
* 회원가입 통신 시 필요한 DTO 생성

## 변경 로직
회원가입 Activity가 로컬에서 작동하도록 되어있던 intent 코드를 삭제하고 서버에 authorityDtoSet, loginId, phoneNumber, username를 @Body로 전송하도록 변경하였습니다 

## To Reviewer
> 안드로이드 에뮬레이터를 이용한 Retrofit 통신을 위해서는 통신 port를 4903으로 변경해야 정상적으로 작동합니다
> Retrofit Service에 통신 메소드를 작성하고 Client를 호출하면 통신이 가능합니다
> 결합도를 낮추기 위해 추후에 Client의 요소들을 DI하도록 바꾸겠습니다

Closes #26 